### PR TITLE
feat(users): add superadmin-only role change endpoint

### DIFF
--- a/config/permissions.py
+++ b/config/permissions.py
@@ -30,6 +30,15 @@ class IsTrainer(permissions.BasePermission):
         return request.user.role == "trainer"
 
 
+class IsSuperAdmin(permissions.BasePermission):
+    """Allows access only to users with superadmin role."""
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if not request.user or not request.user.is_authenticated:
+            return False
+        return request.user.role == "superadmin"
+
+
 class IsAdminOrOperatorOrReadOnly(permissions.BasePermission):
     """Allows read-only access to any authenticated user, write access to admin/operator/superadmin."""
 

--- a/users/api/serializers.py
+++ b/users/api/serializers.py
@@ -88,6 +88,15 @@ class UserCreateSerializer(_FiscalCodeNormalizeMixin, serializers.ModelSerialize
         )
 
 
+class UserRoleSerializer(serializers.ModelSerializer):
+    """Serializer for the superadmin-only role change endpoint."""
+
+    class Meta:
+        model = CustomUser
+        fields: list[str] = ["id", "username", "role"]
+        read_only_fields: list[str] = ["id", "username"]
+
+
 class UserMeSerializer(_FiscalCodeNormalizeMixin, serializers.ModelSerializer):
     """Serializer for the authenticated user's own profile."""
 

--- a/users/api/serializers.py
+++ b/users/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from users.models import CustomUser
+from users.models import CustomUser, UserRole
 
 
 class _FiscalCodeNormalizeMixin:
@@ -90,6 +90,8 @@ class UserCreateSerializer(_FiscalCodeNormalizeMixin, serializers.ModelSerialize
 
 class UserRoleSerializer(serializers.ModelSerializer):
     """Serializer for the superadmin-only role change endpoint."""
+
+    role = serializers.ChoiceField(choices=UserRole.choices, required=True)
 
     class Meta:
         model = CustomUser

--- a/users/api/views.py
+++ b/users/api/views.py
@@ -4,13 +4,14 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from config.permissions import IsAdminOrOperator
+from config.permissions import IsAdminOrOperator, IsSuperAdmin
 from users.models import CustomUser
 from .serializers import (
     UserListSerializer,
     UserDetailSerializer,
     UserCreateSerializer,
     UserMeSerializer,
+    UserRoleSerializer,
 )
 
 
@@ -32,6 +33,8 @@ class UserViewSet(viewsets.ModelViewSet):
             return UserListSerializer
         if self.action == "me":
             return UserMeSerializer
+        if self.action == "set_role":
+            return UserRoleSerializer
         return UserDetailSerializer
 
     def destroy(self, request: Request, *args, **kwargs) -> Response:
@@ -40,6 +43,15 @@ class UserViewSet(viewsets.ModelViewSet):
         user.is_active = False
         user.save(update_fields=["is_active"])
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=True, methods=["patch"], permission_classes=[IsSuperAdmin])
+    def set_role(self, request: Request, pk: int | None = None) -> Response:
+        """Change a user's role. Restricted to superadmin only."""
+        user: CustomUser = self.get_object()
+        serializer = UserRoleSerializer(user, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
 
     @action(detail=False, methods=["get", "patch"], permission_classes=[IsAuthenticated])
     def me(self, request: Request) -> Response:

--- a/users/api/views.py
+++ b/users/api/views.py
@@ -48,7 +48,7 @@ class UserViewSet(viewsets.ModelViewSet):
     def set_role(self, request: Request, pk: int | None = None) -> Response:
         """Change a user's role. Restricted to superadmin only."""
         user: CustomUser = self.get_object()
-        serializer = UserRoleSerializer(user, data=request.data, partial=True)
+        serializer = UserRoleSerializer(user, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -169,3 +169,70 @@ class UserCRUDTests(TestCase):
         response = self.client.get(f"/api/v1/users/{self.member.pk}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["username"], "member")
+
+
+class UserRoleChangeTests(TestCase):
+    """Tests for PATCH /api/v1/users/{id}/set_role/ endpoint."""
+
+    def setUp(self) -> None:
+        self.client: APIClient = APIClient()
+        self.superadmin: CustomUser = CustomUser.objects.create_user(
+            username="superadmin",
+            email="superadmin@example.com",
+            password="superpass123",
+            role=UserRole.SUPERADMIN,
+        )
+        self.admin: CustomUser = CustomUser.objects.create_user(
+            username="admin",
+            email="admin@example.com",
+            password="adminpass123",
+            role=UserRole.ADMIN,
+        )
+        self.member: CustomUser = CustomUser.objects.create_user(
+            username="member",
+            email="member@example.com",
+            password="memberpass123",
+            role=UserRole.MEMBER,
+        )
+
+    def test_superadmin_can_change_role(self) -> None:
+        self.client.force_authenticate(user=self.superadmin)
+        response = self.client.patch(
+            f"/api/v1/users/{self.member.pk}/set_role/",
+            {"role": "trainer"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["role"], "trainer")
+        self.member.refresh_from_db()
+        self.assertEqual(self.member.role, "trainer")
+
+    def test_admin_cannot_change_role(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.patch(
+            f"/api/v1/users/{self.member.pk}/set_role/",
+            {"role": "operator"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_member_cannot_change_role(self) -> None:
+        self.client.force_authenticate(user=self.member)
+        response = self.client.patch(
+            f"/api/v1/users/{self.member.pk}/set_role/",
+            {"role": "admin"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_cannot_change_role(self) -> None:
+        response = self.client.patch(
+            f"/api/v1/users/{self.member.pk}/set_role/",
+            {"role": "admin"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_role_returns_400(self) -> None:
+        self.client.force_authenticate(user=self.superadmin)
+        response = self.client.patch(
+            f"/api/v1/users/{self.member.pk}/set_role/",
+            {"role": "god"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -236,3 +236,11 @@ class UserRoleChangeTests(TestCase):
             {"role": "god"},
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_role_returns_400(self) -> None:
+        self.client.force_authenticate(user=self.superadmin)
+        response = self.client.patch(
+            f"/api/v1/users/{self.member.pk}/set_role/",
+            {},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- add patch /api/v1/users/{id}/set_role/ restricted to IsSuperAdmin
- introduce IsSuperAdmin permission class and UserRoleSerializer
- cover all permission scenarios with 5 dedicated tests